### PR TITLE
Inline arrays into structs

### DIFF
--- a/Iril/AnonymousStruct.cs
+++ b/Iril/AnonymousStruct.cs
@@ -14,6 +14,7 @@ namespace Iril
         public FieldReference[] ElementFields;
 
         public static readonly IEqualityComparer<TypeReference[]> TypesEquality = new TEq ();
+        public static readonly IEqualityComparer<Types.LType[]> LTypesEquality = new LTEq ();
 
         class TEq : IEqualityComparer<TypeReference[]>
         {
@@ -36,6 +37,31 @@ namespace Iril
                 var h = 0;
                 foreach (var t in x) {
                     h += t.FullName.GetHashCode ();
+                }
+                return h;
+            }
+        }
+
+        class LTEq : IEqualityComparer<Types.LType[]>
+        {
+            public bool Equals (Types.LType[] x, Types.LType[] y)
+            {
+                if (x.Length != y.Length)
+                    return false;
+                for (int i = 0; i < x.Length; i++) {
+                    var t = x[i];
+                    var u = y[i];
+                    if (!t.StructurallyEquals (u))
+                        return false;
+                }
+                return true;
+            }
+
+            public int GetHashCode (Types.LType[] x)
+            {
+                var h = 0;
+                foreach (var t in x) {
+                    h += t.GetStructuralHashCode ();
                 }
                 return h;
             }

--- a/Iril/Emitter.cs
+++ b/Iril/Emitter.cs
@@ -11,7 +11,7 @@ namespace Iril
 {
     abstract class Emitter
     {
-        public const int ShouldTrace = 3;
+        public const int ShouldTrace = 0;
 
         // Input
         protected readonly Compilation compilation;

--- a/Iril/Emitter.cs
+++ b/Iril/Emitter.cs
@@ -11,7 +11,7 @@ namespace Iril
 {
     abstract class Emitter
     {
-        public const int ShouldTrace = 2;
+        public const int ShouldTrace = 3;
 
         // Input
         protected readonly Compilation compilation;
@@ -28,7 +28,9 @@ namespace Iril
 
         readonly Dictionary<(string, int), VariableDefinition> vectorTemps = new Dictionary<(string, int), VariableDefinition> ();
         readonly SymbolTable<VariableDefinition> structTempLocals = new SymbolTable<VariableDefinition> ();
-        readonly Dictionary<TypeReference[], VariableDefinition> astructTempLocals = new Dictionary<TypeReference[], VariableDefinition> (AnonymousStruct.TypesEquality);
+        readonly Dictionary<string, VariableDefinition> trTempLocals = new Dictionary<string, VariableDefinition> ();
+        readonly Dictionary<LType[], VariableDefinition> astructTempLocals =
+            new Dictionary<LType[], VariableDefinition> (AnonymousStruct.LTypesEquality);
 
         protected Emitter(Compilation compilation, Module module, MethodDefinition methodDefinition)
         {
@@ -292,9 +294,11 @@ namespace Iril
                         }
                         else
                         {
-                            EmitValue(index.Value, index.Type);
-                            EmitValue(new IR.IntegerConstant(esize), index.Type);
-                            Emit(il.Create(OpCodes.Mul));
+                            EmitValue (index.Value, index.Type);
+                            if (esize != 1) {
+                                EmitValue (new IR.IntegerConstant (esize), index.Type);
+                                Emit (il.Create (OpCodes.Mul));
+                            }
                         }
                         Emit(il.Create(OpCodes.Conv_U));
                         Emit(il.Create(OpCodes.Add));
@@ -334,8 +338,10 @@ namespace Iril
                     }
                     else {
                         EmitValue (index.Value, index.Type);
-                        EmitValue (new IR.IntegerConstant (esize), index.Type);
-                        Emit (il.Create (OpCodes.Mul));
+                        if (esize != 1) {
+                            EmitValue (new IR.IntegerConstant (esize), index.Type);
+                            Emit (il.Create (OpCodes.Mul));
+                        }
                         Emit (il.Create (OpCodes.Conv_U));
                         Emit (il.Create (OpCodes.Add));
                     }
@@ -581,13 +587,24 @@ namespace Iril
 
         protected VariableDefinition GetStructTempLocal (LiteralStructureType type)
         {
-            var key = type.Elements.Select (x => compilation.GetClrType (x, module: this.module)).ToArray ();
+            var key = type.Elements;
             if (astructTempLocals.TryGetValue (key, out var v))
                 return v;
             var t = compilation.GetClrType (type, module: this.module);
             v = new VariableDefinition (t);
             body.Variables.Add (v);
             astructTempLocals[key] = v;
+            return v;
+        }
+
+        protected VariableDefinition GetStructTempLocal (TypeReference type)
+        {
+            var key = type.FullName;
+            if (trTempLocals.TryGetValue (key, out var v))
+                return v;
+            v = new VariableDefinition (type);
+            body.Variables.Add (v);
+            trTempLocals[key] = v;
             return v;
         }
 

--- a/Iril/Emitter.cs
+++ b/Iril/Emitter.cs
@@ -323,9 +323,6 @@ namespace Iril
                 }
                 else if (t is Types.ArrayType artt)
                 {
-                    if (i > 0) {
-                        Emit (il.Create (OpCodes.Ldind_I));
-                    }
                     var esize = artt.ElementType.GetByteSize(module);
                     if (index.Value is Constant ic) {
                         var offset = (int)esize * ic.Int32Value;

--- a/Iril/FunctionCompiler.cs
+++ b/Iril/FunctionCompiler.cs
@@ -1533,7 +1533,7 @@ namespace Iril
             var et = compilation.GetClrType(store.Value.Type, module: module);
             if (store.Value.Type is IntegerType intt)
             {
-                switch (intt.Bits)
+                switch (Compilation.RoundUpIntBits (intt.Bits))
                 {
                     case 8:
                         Emit(il.Create(OpCodes.Stind_I1));
@@ -1602,7 +1602,7 @@ namespace Iril
             var et = compilation.GetClrType(load.Type, module: module);
             if (load.Type is IntegerType intt)
             {
-                switch (intt.Bits)
+                switch (Compilation.RoundUpIntBits (intt.Bits))
                 {
                     case 8:
                         Emit(il.Create(OpCodes.Ldind_I1));

--- a/Iril/Module.cs
+++ b/Iril/Module.cs
@@ -26,7 +26,7 @@ namespace Iril
         /// </summary>
         public string TargetDatalayout = "";
 
-        public long PointerByteSize = 8;
+        public int PointerByteSize = 8;
 
         /// <summary>
         /// A series of identifiers delimited by the minus sign character

--- a/Iril/Types/ArrayType.cs
+++ b/Iril/Types/ArrayType.cs
@@ -15,6 +15,18 @@ namespace Iril.Types
 
         public override long GetByteSize (Module module) => Length * ElementType.GetByteSize (module);
 
+        public override int GetAlignment (Module module) => ElementType.GetAlignment (module);
+
         public override string ToString () => $"[{Length} x {ElementType}]";
+
+        public override bool StructurallyEquals (LType other) =>
+            other is ArrayType a
+            && Length == a.Length
+            && ElementType.StructurallyEquals (a.ElementType);
+
+        public override int GetStructuralHashCode () =>
+            234
+            + Length.GetHashCode ()
+            + ElementType.GetStructuralHashCode ();
     }
 }

--- a/Iril/Types/FloatType.cs
+++ b/Iril/Types/FloatType.cs
@@ -5,7 +5,7 @@ namespace Iril.Types
     public class FloatType : LType
     {
         public static readonly FloatType Half = new FloatType ("half", 16);
-        public static readonly FloatType Float = new FloatType ("float", 21);
+        public static readonly FloatType Float = new FloatType ("float", 32);
         public static readonly FloatType Double = new FloatType ("double", 64);
         public static readonly FloatType FP128 = new FloatType ("fp128", 128);
         public static readonly FloatType X86_FP80 = new FloatType ("x86_fp80", 80);
@@ -23,5 +23,15 @@ namespace Iril.Types
         public override string ToString () => Symbol.ToString ();
 
         public override long GetByteSize (Module module) => Bits == 32 ? 4L : 8L;
+
+        public override int GetAlignment (Module module) => Bits / 8;
+
+        public override bool StructurallyEquals (LType other) =>
+            other is FloatType a
+            && Bits == a.Bits;
+
+        public override int GetStructuralHashCode () =>
+            456
+            + Bits.GetHashCode ();
     }
 }

--- a/Iril/Types/FunctionType.cs
+++ b/Iril/Types/FunctionType.cs
@@ -18,5 +18,37 @@ namespace Iril.Types
             $"{ReturnType} ({String.Join(", ", (object[])ParameterTypes)})";
 
         public override long GetByteSize (Module module) => module.PointerByteSize;
+
+        public override int GetAlignment (Module module) => module.PointerByteSize;
+
+        public override bool StructurallyEquals (LType other) =>
+            other is FunctionType a
+            && ReturnType.StructurallyEquals (a.ReturnType)
+            && ParametersEqual (a.ParameterTypes);
+
+        bool ParametersEqual (LType[] parameterTypes)
+        {
+            if (ParameterTypes.Length != parameterTypes.Length)
+                return false;
+            for (var i = 0; i < ParameterTypes.Length; i++) {
+                if (!ParameterTypes[i].StructurallyEquals (parameterTypes[i]))
+                    return false;
+            }
+            return true;
+        }
+
+        public override int GetStructuralHashCode () =>
+            234
+            + ReturnType.GetStructuralHashCode ()
+            + GetParametersHash ();
+
+        int GetParametersHash ()
+        {
+            var h = ParameterTypes.Length.GetHashCode ();
+            for (var i = 0; i < ParameterTypes.Length; i++) {
+                h += ParameterTypes[i].GetStructuralHashCode ();
+            }
+            return h;
+        }
     }
 }

--- a/Iril/Types/IntegerType.cs
+++ b/Iril/Types/IntegerType.cs
@@ -24,6 +24,8 @@ namespace Iril.Types
 
         public override long GetByteSize (Module module) => Bits < 8 ? 1 : Bits / 8;
 
+        public override int GetAlignment (Module module) => Bits < 8 ? 1 : Bits / 8;
+
         public static IntegerType Parse (string text, int startIndex, int length)
         {
             var i = startIndex + 1;
@@ -55,5 +57,13 @@ namespace Iril.Types
             var bits = int.Parse (bitText);
             return new IntegerType (bits);
         }
+
+        public override bool StructurallyEquals (LType other) =>
+            other is IntegerType a
+            && Bits == a.Bits;
+
+        public override int GetStructuralHashCode () =>
+            345
+            + Bits.GetHashCode ();
     }
 }

--- a/Iril/Types/LType.cs
+++ b/Iril/Types/LType.cs
@@ -7,6 +7,12 @@ namespace Iril.Types
         public virtual LType Resolve (Module module) => this;
 
         public abstract long GetByteSize (Module module);
+
+        public abstract bool StructurallyEquals (LType other);
+
+        public abstract int GetStructuralHashCode ();
+
+        public abstract int GetAlignment(Module module);
     }
 
     public class VarArgsType : LType
@@ -16,5 +22,11 @@ namespace Iril.Types
         public override long GetByteSize (Module module) => 0L;
 
         public override string ToString () => "...";
+
+        public override bool StructurallyEquals (LType other) => other is VarArgsType;
+
+        public override int GetStructuralHashCode () => 123;
+
+        public override int GetAlignment (Module module) => module.PointerByteSize;
     }
 }

--- a/Iril/Types/NamedType.cs
+++ b/Iril/Types/NamedType.cs
@@ -21,5 +21,15 @@ namespace Iril.Types
         }
 
         public override long GetByteSize (Module module) => Resolve (module).GetByteSize (module);
+
+        public override int GetAlignment (Module module) => Resolve (module).GetAlignment (module);
+
+        public override bool StructurallyEquals (LType other) =>
+            other is NamedType a
+            && Symbol == a.Symbol;
+
+        public override int GetStructuralHashCode () =>
+            678
+            + Symbol.GetHashCode ();
     }
 }

--- a/Iril/Types/PointerType.cs
+++ b/Iril/Types/PointerType.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Mono.Cecil;
 
 namespace Iril.Types
 {
@@ -19,5 +20,15 @@ namespace Iril.Types
         public override string ToString () => $"{ElementType}*";
 
         public override long GetByteSize (Module module) => module.PointerByteSize;
+
+        public override int GetAlignment (Module module) => module.PointerByteSize;
+
+        public override bool StructurallyEquals (LType other) =>
+            other is PointerType a
+            && ElementType.StructurallyEquals (a.ElementType);
+
+        public override int GetStructuralHashCode () =>
+            789
+            + ElementType.GetStructuralHashCode ();
     }
 }

--- a/Iril/Types/StructureType.cs
+++ b/Iril/Types/StructureType.cs
@@ -12,7 +12,15 @@ namespace Iril.Types
     {
         public static readonly OpaqueStructureType Opaque = new OpaqueStructureType ();
 
-        public override long GetByteSize (Module module) => 0;
+        public override long GetByteSize (Module module) => module.PointerByteSize;
+
+        public override int GetAlignment (Module module) => module.PointerByteSize;
+
+        public override bool StructurallyEquals (LType other) =>
+            other is OpaqueStructureType;
+
+        public override int GetStructuralHashCode () =>
+            1012;
     }
 
     public class LiteralStructureType : StructureType
@@ -30,6 +38,36 @@ namespace Iril.Types
             $"{{{string.Join(", ", (object[])Elements)}}}";
 
         public override long GetByteSize (Module module) => Elements.Sum (x => x.GetByteSize (module));
+
+        public override int GetAlignment (Module module) => Elements[0].GetAlignment (module);
+
+        public override bool StructurallyEquals (LType other) =>
+            other is LiteralStructureType a
+            && ElementsEqual (a.Elements);
+
+        bool ElementsEqual (LType[] parameterTypes)
+        {
+            if (Elements.Length != parameterTypes.Length)
+                return false;
+            for (var i = 0; i < Elements.Length; i++) {
+                if (!Elements[i].StructurallyEquals (parameterTypes[i]))
+                    return false;
+            }
+            return true;
+        }
+
+        public override int GetStructuralHashCode () =>
+            1123
+            + GetElementsHash ();
+
+        int GetElementsHash ()
+        {
+            var h = Elements.Length.GetHashCode ();
+            for (var i = 0; i < Elements.Length; i++) {
+                h += Elements[i].GetStructuralHashCode ();
+            }
+            return h;
+        }
     }
 
     public class PackedStructureType : LiteralStructureType

--- a/Iril/Types/VectorType.cs
+++ b/Iril/Types/VectorType.cs
@@ -19,5 +19,17 @@ namespace Iril.Types
         }
 
         public override long GetByteSize (Module module) => Length * ElementType.GetByteSize (module);
+
+        public override int GetAlignment (Module module) => (int)GetByteSize (module);
+
+        public override bool StructurallyEquals (LType other) =>
+            other is VectorType a
+            && Length == a.Length
+            && ElementType.StructurallyEquals (a.ElementType);
+
+        public override int GetStructuralHashCode () =>
+            890
+            + Length.GetHashCode ()
+            + ElementType.GetStructuralHashCode ();
     }
 }

--- a/Iril/Types/VoidType.cs
+++ b/Iril/Types/VoidType.cs
@@ -11,6 +11,14 @@ namespace Iril.Types
 
         public override string ToString () => "void";
 
-        public override long GetByteSize (Module module) => 0;
+        public override long GetByteSize (Module module) => module.PointerByteSize;
+
+        public override int GetAlignment (Module module) => module.PointerByteSize;
+
+        public override bool StructurallyEquals (LType other) =>
+            other is VoidType;
+
+        public override int GetStructuralHashCode () =>
+            901;
     }
 }


### PR DESCRIPTION
This is done so that structs have the right size and to match the C memory model.